### PR TITLE
fix: duplicate local variant codes

### DIFF
--- a/frontend/src/components/ProductModal.jsx
+++ b/frontend/src/components/ProductModal.jsx
@@ -102,6 +102,7 @@ function ProductModal({ productUpdate, onClose, onSubmit }) {
             type: "Variant"
         })
     }
+
     const handleUpdate = (variant) => {
         setVariantUpdate(variant)
         setModalVariant(true)
@@ -149,7 +150,7 @@ function ProductModal({ productUpdate, onClose, onSubmit }) {
                     <button type="submit">{productUpdate ? 'Actualizar' : 'Crear'}</button>
                 </form>
 
-                {modalVariant && <VariantModal onSubmitVariant={onSubmitVariant} variantUpdate={variantUpdate} closeModal={() => { setModalVariant(false) }} />}
+                {modalVariant && <VariantModal onSubmitVariant={onSubmitVariant} variants={variants} variantUpdate={variantUpdate} closeModal={() => { setModalVariant(false) }} />}
                 <section className="w-full flex flex-col items-center justify-center m-auto gap-4">
                     {variants.map((variant) => (
                         <div key={variant.localId} className="flex items-center justify-center gap-4">

--- a/frontend/src/components/ProductModal.jsx
+++ b/frontend/src/components/ProductModal.jsx
@@ -93,11 +93,11 @@ function ProductModal({ productUpdate, onClose, onSubmit }) {
         setModalVariant(true)
     }
 
-    const handleDelete = (code) => {
+    const handleDelete = (id) => {
         deleteAlert({
             deleteFunction: () => {
-                deleteVariant(code)
-                setVariants((prev => prev.filter(p => p.code !== code)))
+                deleteVariant(id)
+                setVariants((prev => prev.filter(p => p.localId !== id)))
             },
             type: "Variant"
         })

--- a/frontend/src/components/VariantModal.jsx
+++ b/frontend/src/components/VariantModal.jsx
@@ -4,17 +4,27 @@ import { notify } from '../utils/notifyToast.js'
 import { variantSchemaWithOutProductId } from '../../../validation/productVariantsSchema.js'
 import { useState, useRef } from 'react'
 
-function VariantModal({ onSubmitVariant, variantUpdate, closeModal }) {
+function VariantModal({ onSubmitVariant, variants, variantUpdate, closeModal }) {
     const [image, setImage] = useState(null)
     const fileInputRef = useRef(null)
 
-    const { register, handleSubmit, formState: { errors } } = useForm({
+    const { register, handleSubmit, formState: { errors }, setError } = useForm({
         mode: 'onChange',
         resolver: zodResolver(variantUpdate ? variantSchemaWithOutProductId.partial() : variantSchemaWithOutProductId),
         defaultValues: variantUpdate
     })
 
     const isValid = (data) => {
+        for (const variant of variants) {
+            if (data.code === variant.code && variantUpdate?.localId !== variant.localId) {
+                const message = "éste código ya está en uso"
+                setError("code", {
+                    type: "server",
+                    message: message
+                })
+                return notify('error', message)
+            }
+        }
         if (image) {
             data.image = image
         }


### PR DESCRIPTION
### 👾 Bug Fix: Validación previa y aviso antes de crear variantes con códigos ya existentes

- Se agregó validación en el formulario de creación/edición de variantes para evitar códigos únicos repetidos dentro de un mismo producto antes de enviar al backend.
- El mensaje de error se muestra directamente en el formulario debajo del campo `code` que genera el conflicto, utilizando `setError` de `React Hook Form`.
- Se corrigió el `handleDelete` de variantes locales, que ahora elimina correctamente usando `localId` en lugar de `code`.

Closes #16 