### PR TITLE
fix: reduce unnecessary requests and sync UI after variant deletion

### DIFF
--- a/backend/src/middlewares/productVariantMiddlewares.js
+++ b/backend/src/middlewares/productVariantMiddlewares.js
@@ -76,9 +76,7 @@ export const validateUniqueCode = async(req, res) => {
                 code: code
             }
         })
-        console.log("code", code, "variantId", variantId, "codeExist", codeExist)
         if (codeExist && codeExist.id !== variantId) return res.status(400).json({message: "Ese código ya se encuentra en uso"})
-        /* if (variantId && codeExist.id !== variantId ||  codeExist && variantId == null) return res.status(400).json({message: "Ese código ya se encuentra en uso"}) */
 
         return res.status(200).json({success: true})
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
         "@tailwindcss/vite": "^4.1.7",
+        "lodash.isequal": "^4.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.56.4",
@@ -3016,6 +3017,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
     "@tailwindcss/vite": "^4.1.7",
+    "lodash.isequal": "^4.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.56.4",

--- a/frontend/src/components/ProductModal.jsx
+++ b/frontend/src/components/ProductModal.jsx
@@ -55,7 +55,6 @@ function ProductModal({ productUpdate, onClose, onSubmit }) {
                 variant.image = imageUrl
             }
         }
-        console.log(fullProduct)
         const result = productUpdate ? await updateProduct(fullProduct, productUpdate, setError) : await createProduct(fullProduct, setError)
 
         if (!result.success) {
@@ -86,7 +85,6 @@ function ProductModal({ productUpdate, onClose, onSubmit }) {
             ? setVariants((prev => prev.map(p => p.localId === data.localId ? data : p)))
             : setVariants((prev) => [...prev, data])
         setModalVariant(false)
-        console.log("data en product Modal", data)
     }
 
     const handleCreate = () => {
@@ -94,11 +92,14 @@ function ProductModal({ productUpdate, onClose, onSubmit }) {
         setModalVariant(true)
     }
 
-    const handleDelete = (id) => {
+    const handleDelete = (variant) => {
         deleteAlert({
             deleteFunction: () => {
-                deleteVariant(id)
-                setVariants((prev => prev.filter(p => p.localId !== id)))
+                if (variant.id) {
+                    deleteVariant(variant.localId)
+                    console.log("eliminando variante que ya se encontraba en la database")
+                }
+                setVariants((prev => prev.filter(p => p.localId !== variant.localId)))
             },
             type: "Variant"
         })
@@ -162,7 +163,7 @@ function ProductModal({ productUpdate, onClose, onSubmit }) {
                             <p>Stock: {variant.stock}</p>
                             {variant.image && <img src={typeof variant.image === 'string' ? variant.image : URL.createObjectURL(variant.image)} className="w-20 h-20 object-cover" />}
                             <button onClick={() => { handleUpdate(variant) }}>Editar</button>
-                            <button onClick={() => { handleDelete(variant.localId) }}>Eliminar</button>
+                            <button onClick={() => { handleDelete(variant) }}>Eliminar</button>
                         </div>
                     ))}
                 </section>

--- a/frontend/src/components/VariantModal.jsx
+++ b/frontend/src/components/VariantModal.jsx
@@ -29,8 +29,6 @@ function VariantModal({ onSubmitVariant, variants, variantUpdate, closeModal }) 
         }
         data.localId = variantUpdate?.localId || crypto.randomUUID()
 
-        console.log("data en variant Modal antes del check", data)
-
         const result = await getOneVariant(data, setError)
         if (!result.success) {
             notify('error', 'ese codigo ya tiene dueño')

--- a/frontend/src/context/ProductContext.jsx
+++ b/frontend/src/context/ProductContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useEffect, useState, useContext } from "react";
 import { notify } from "../utils/notifyToast.js";
-import { error } from "zod/v4/locales/ar.js";
+import isEqual from 'lodash.isequal'
 
 const ProductContext = createContext()
 
@@ -70,6 +70,18 @@ export function ProductProvider({ children }) {
 
     const updateProduct = async (formUpdateProduct, productUpdate, setError) => {
         try {
+            const productUpdateWithoutId = {}
+
+            for (const [field, value] of Object.entries(productUpdate)) {
+                if (field !== 'id') {
+                    productUpdateWithoutId[field] = value
+                }
+            }
+
+            if (isEqual(formUpdateProduct, productUpdateWithoutId)) {
+                return { success: true }
+            }
+
             const res = await fetch(`http://localhost:3000/api/products/${productUpdate.id}`, {
                 method: 'PUT',
                 headers: {
@@ -100,7 +112,7 @@ export function ProductProvider({ children }) {
             notify('success', 'Producto actualizado con éxito')
             return { success: true }
         } catch (error) {
-            console.log("Error interno del servidor durante el proceso")
+            console.log("Error interno del servidor durante el proceso", error)
         }
     }
 

--- a/frontend/src/hooks/useVariants.js
+++ b/frontend/src/hooks/useVariants.js
@@ -1,7 +1,9 @@
 import { useState } from "react"
 import { notify } from "../utils/notifyToast.js"
+import { useProducts } from "../context/ProductContext.jsx"
 
 export function useVariants () {
+    const {fetchProducts} = useProducts()
     const [variants, setVariants] = useState([])
 
     const fetchVariants = async() => {
@@ -60,6 +62,7 @@ export function useVariants () {
         })
         const data = await res.json()
         setVariants((prev) => (prev.filter((p) => p.id !== id)))
+        fetchProducts()
         notify('success', 'Variante eliminada con éxito')
     }
 


### PR DESCRIPTION
### 👾 Bug Fix: Reduciendo peticiones innecesarias al servidor en productos y variantes

- Se evita enviar una petición `PUT` al backend si el producto no recibió cambios, mejorando el rendimiento.
- Al eliminar variantes, si la variante es local (sin `id`), se evita llamar al servidor y se actualiza solo el estado local.
- Si la variante sí existe en base de datos, se elimina y se realiza un `fetch` de productos para mantener la UI sincronizada en tiempo real.

Closes #3