### PR TITLE
fix: render immediate variant after creation and update product context instead of fetch

### DIFF
--- a/frontend/src/context/ProductContext.jsx
+++ b/frontend/src/context/ProductContext.jsx
@@ -116,12 +116,24 @@ export function ProductProvider({ children }) {
         }
     }
 
+    const addVariantToProduct = (productId, newVariant) => {
+        setProducts(prev => prev.map(product => product.id === productId ? { ...product, variants: [...product.variants, newVariant] } : product))
+    }
+
+    const deleteVariantToProduct = (productId, variantId) => {
+        setProducts(prev => prev.map(product => product.id === productId ? { ...product, variants: product.variants.filter(v => v.id !== variantId) } : product))
+    }
+
+    const updateVariantToProduct = (productId, variantId, variantUpdated) => {
+        setProducts(prev => prev.map(product => product.id === productId ? { ...product, variants: product.variants.map(v => v.id === variantId ? variantUpdated : v) } : product))
+    }
+
     useEffect(() => {
         fetchProducts()
     }, [])
 
     return (
-        <ProductContext.Provider value={{ products, createProduct, fetchProducts, deleteProduct, updateProduct }}>
+        <ProductContext.Provider value={{ products, createProduct, fetchProducts, deleteProduct, updateProduct, addVariantToProduct, deleteVariantToProduct, updateVariantToProduct }}>
             {children}
         </ProductContext.Provider>
     )

--- a/frontend/src/hooks/useVariants.js
+++ b/frontend/src/hooks/useVariants.js
@@ -5,7 +5,7 @@ import { uploadImage } from '../utils/uploads.js'
 import isEqual from 'lodash.isequal'
 
 export function useVariants () {
-    const {fetchProducts} = useProducts()
+    const { addVariantToProduct, fetchProducts, deleteVariantToProduct, updateVariantToProduct} = useProducts()
     const [variants, setVariants] = useState([])
 
     const fetchVariants = async() => {
@@ -48,7 +48,7 @@ export function useVariants () {
                 body: JSON.stringify(formData)
             })
             if (!res.ok){
-                console.log("Se rompio todo", res)
+                console.log("Hubo un error durante la creación", res)
             }
             const data = await res.json()
             notify('success', 'Variante creada con éxito!')
@@ -67,7 +67,7 @@ export function useVariants () {
         })
         const data = await res.json()
         setVariants((prev) => (prev.filter((p) => p.id !== id)))
-        fetchProducts()
+        await deleteVariantToProduct(data.productId, id)
         notify('success', 'Variante eliminada con éxito')
     }
 
@@ -88,11 +88,11 @@ export function useVariants () {
             if (!res.ok) {
                 return {success: false, errors: data.errors}
             }
-            fetchProducts()
+            await updateVariantToProduct(data.productId, data.id, data)
             notify('success', 'Variante actualizada con éxito')
         }
         catch (error){
-            return res.status(400).json({error: error})
+            return {success: false}
         }
     }
 
@@ -122,7 +122,13 @@ export function useVariants () {
             } else {
                 const resultVariant = await createVariant(fullVariant)
                 if (resultVariant?.id) {
-                    setVariants(prev => [...prev.filter(p => p.localId !== data.localId), { ...fullVariant, id: resultVariant.id }])
+                    const newVariant = {
+                        ...fullVariant,
+                        id: resultVariant.id
+                    }
+                    setVariants(prev => [...prev.filter(p => p.localId !== data.localId), newVariant])
+
+                    await addVariantToProduct(productUpdate.id, newVariant)
                 }
             }
         } else {


### PR DESCRIPTION
### 👾 Bug Fix: Renderizado inmediato de variantes y reemplazo de fetch por actualización de contexto

- Se solucionó el problema donde las variantes recién creadas no se visualizaban hasta recargar manualmente.
- Se implementaron actualizaciones directas al `ProductContext` para reflejar inmediatamente los cambios al crear, editar o eliminar variantes, reemplazando así el uso de `fetchProducts`.
- Se mejoró la reactividad del sistema y evita llamadas innecesarias al backend.

Closes #31 