### PR TITLE
Enhancement: Improvement sales and entries page

### DIFF
--- a/backend/src/controller/metrics.controller.js
+++ b/backend/src/controller/metrics.controller.js
@@ -1,38 +1,10 @@
-import { size } from "zod/v4"
 import prisma from "../db.js"
+import { filterByDate } from "../utils/filterByDate.js"
 
 export const getMetrics = async(req, res) => {
     try {
         const topN = 5
-        const currentDate = new Date()
-        const year = Number(req.query.year) || currentDate.getFullYear()
-        const month = Number(req.query.month) || currentDate.getMonth()
-        const minDay = Number(req.query.minDay) || 1
-        const lastDayMonth = new Date (year, month, 0)
-        const maxDay = Number(req.query.maxDay) || lastDayMonth.getDate()
-        const where = {}
-        where.date = {}
-        if (req.query.year){
-            if (req.query.month){
-                where.date.gte= new Date (year, month -1, minDay)
-                if (req.query.minDay){
-                    if (req.query.maxDay){
-                        where.date.lt = new Date (year, month -1, maxDay +1)
-                    }else {
-                        where.date.lt = new Date (year, month - 1, minDay + 1)
-                    }
-                }else {
-                    where.date.lt = new Date (year, month -1, maxDay +1)
-                }
-            }else {
-                where.date.gte = new Date (year, 0, 1)
-                where.date.lt = new Date (year + 1, 0, 0)
-            }
-        }else {
-            where.date.gte = new Date (year, month, minDay)
-            where.date.lt = new Date (year, month, maxDay)
-        }
-        
+        const where = filterByDate(req.query)       
         const sales = await prisma.sales.findMany({
             where,
             include: {

--- a/backend/src/controller/sales.controller.js
+++ b/backend/src/controller/sales.controller.js
@@ -70,12 +70,9 @@ export const getAllSales = async(req, res) => {
 export const deleteSale = async(req, res) => {
     try {
         const result = await prisma.$transaction( async(tx) => {
-            const idSelected = req.params.id
-            const saleExist = await tx.sales.findFirst({where: {id: idSelected}, include: {items: true}})
-            if (!saleExist) throw new Error(`Venta inexistente: ${idSelected}`)
-
+            const sale = req.sale
             const variantsThatNotExist = {}
-            for (const item of saleExist.items){
+            for (const item of sale.items){
                 const variantExist = await tx.productVariant.findFirst({where: {id: item.variantId}})
                 if (!variantExist) {
                     variantsThatNotExist[item.variantId] = `variante inexistente: ${item.variantId}`
@@ -86,7 +83,7 @@ export const deleteSale = async(req, res) => {
 
             const saleDeleted = await tx.sales.delete({
                 where: {
-                    id: idSelected
+                    id: sale.id
                 },
                 include: {
                     items: true

--- a/backend/src/controller/sales.controller.js
+++ b/backend/src/controller/sales.controller.js
@@ -71,7 +71,6 @@ export const deleteSale = async(req, res) => {
     try {
         const result = await prisma.$transaction( async(tx) => {
             const sale = req.sale
-            console.log(sale)
             const variantsThatNotExist = {}
             for (const item of sale.items){
                 const variantExist = await tx.productVariant.findFirst({where: {id: item.variantId}})

--- a/backend/src/controller/sales.controller.js
+++ b/backend/src/controller/sales.controller.js
@@ -114,3 +114,19 @@ export const deleteSale = async(req, res) => {
         return res.status(500).json({ error: "Error interno durante el proceso" });
     }
 }
+
+export const updateSale = async(req, res ) => {
+    try {
+        const result = await prisma.$transaction( async(tx) => {
+            const id = req.params.id
+            const saleUpdated = await tx.sales.update({
+                data: req.body,
+                where: {id: id}
+            })
+            return {saleUpdated}
+        })
+        return res.json({saleUpdated: result.saleUpdated})
+    } catch (error) {
+        return res.status(500).json({ error: "Error interno durante el proceso" });
+    }
+}

--- a/backend/src/controller/sales.controller.js
+++ b/backend/src/controller/sales.controller.js
@@ -1,4 +1,5 @@
 import prisma from "../db.js"
+import { filterByDate } from "../utils/filterByDate.js"
 export const createNewSale = async(req, res) => {
     try {
         const userId = req.user.id
@@ -46,6 +47,7 @@ export const createNewSale = async(req, res) => {
 
 export const getAllSales = async(req, res) => {
     try {
+        const where = filterByDate(req.query)
         const allSales = await prisma.sales.findMany({
             include: {
                 items: {
@@ -58,7 +60,8 @@ export const getAllSales = async(req, res) => {
                     }
                 },
                 user: true
-            }
+            },
+            where
         })
         return res.json(allSales)
     } catch (error) {

--- a/backend/src/controller/sales.controller.js
+++ b/backend/src/controller/sales.controller.js
@@ -71,6 +71,7 @@ export const deleteSale = async(req, res) => {
     try {
         const result = await prisma.$transaction( async(tx) => {
             const sale = req.sale
+            console.log(sale)
             const variantsThatNotExist = {}
             for (const item of sale.items){
                 const variantExist = await tx.productVariant.findFirst({where: {id: item.variantId}})

--- a/backend/src/controller/sales.controller.js
+++ b/backend/src/controller/sales.controller.js
@@ -112,19 +112,3 @@ export const deleteSale = async(req, res) => {
         return res.status(500).json({ error: "Error interno durante el proceso" });
     }
 }
-
-export const updateSale = async(req, res ) => {
-    try {
-        const result = await prisma.$transaction( async(tx) => {
-            const id = req.params.id
-            const saleUpdated = await tx.sales.update({
-                data: req.body,
-                where: {id: id}
-            })
-            return {saleUpdated}
-        })
-        return res.json({saleUpdated: result.saleUpdated})
-    } catch (error) {
-        return res.status(500).json({ error: "Error interno durante el proceso" });
-    }
-}

--- a/backend/src/controller/sales.controller.js
+++ b/backend/src/controller/sales.controller.js
@@ -47,7 +47,15 @@ export const createNewSale = async(req, res) => {
 
 export const getAllSales = async(req, res) => {
     try {
+        const LIMIT = 8
+        const page = Number(req.query.page) || 1
+        const skip = (page - 1) * LIMIT
+        const take = LIMIT
+
         const where = filterByDate(req.query)
+        const totalCount = await prisma.sales.count({where})
+
+
         const allSales = await prisma.sales.findMany({
             include: {
                 items: {
@@ -61,9 +69,23 @@ export const getAllSales = async(req, res) => {
                 },
                 user: true
             },
-            where
+            where,
+            skip,
+            take,
+            orderBy: {date: 'desc'}
         })
-        return res.json(allSales)
+
+        const totalPages = Math.ceil(totalCount / LIMIT)
+
+        return res.json({
+            allSales,
+            pagination:{
+                total: totalCount,
+                page: page,
+                totalPages: totalPages,
+                limit: LIMIT
+            }
+        })
     } catch (error) {
         console.log(error);
         return res.status(500).json({ error: "Error interno durante el proceso" });

--- a/backend/src/controller/stockEntries.controller.js
+++ b/backend/src/controller/stockEntries.controller.js
@@ -51,7 +51,14 @@ export const createStockEntry = async(req, res) => {
 
 export const getAllStockEntries = async(req, res) => {
     try {
+        const LIMIT = 8
+        const page = Number(req.query.page) || 1
+        const skip = (page - 1) * LIMIT
+        const take = LIMIT
+
         const where = filterByDate(req.query)
+        const totalCount = await prisma.stockEntry.count({where})
+
         const allStockEntries = await prisma.stockEntry.findMany({
         include: {
             items: {
@@ -65,9 +72,24 @@ export const getAllStockEntries = async(req, res) => {
             },
             user: true
         },
-        where
+        where,
+        skip,
+        take,
+        orderBy: {date: 'desc'}
         })
-        return res.json(allStockEntries)
+
+        const totalPages = Math.ceil( totalCount / LIMIT)
+
+
+        return res.json({
+            allStockEntries,
+            pagination: {
+                totalCount: totalCount,
+                totalPages: totalPages,
+                page: page,
+                limit: LIMIT
+            }
+        })
     } catch (error) {
         console.log(error);
         return res.status(500).json({ error: "Error interno durante el proceso" });

--- a/backend/src/controller/stockEntries.controller.js
+++ b/backend/src/controller/stockEntries.controller.js
@@ -74,13 +74,10 @@ export const getAllStockEntries = async(req, res) => {
 export const deleteEntry = async(req, res) =>{
     try {
         const result = await prisma.$transaction( async(tx) => {
-            const idSelected = req.params.id
-            const entryExist = await tx.stockEntry.findFirst({where: {id: idSelected}, include: {items: true}})
-            if (!entryExist) {throw new Error(`Entrada no existente: ${idSelected}`)}
-
+            const stockEntry = req.stockEntry
             const variantsThatNotExist = {}
             const variantsWithLowStock = {}
-            for (const item of entryExist.items){
+            for (const item of stockEntry.items){
                 const variantExist = await tx.productVariant.findFirst({where: {id: item.variantId}})
                 if (!variantExist){
                     variantsThatNotExist[item.variantId] = `Variante inexistente: ${item.variantId}`

--- a/backend/src/controller/stockEntries.controller.js
+++ b/backend/src/controller/stockEntries.controller.js
@@ -92,7 +92,7 @@ export const deleteEntry = async(req, res) =>{
 
             const entryDeleted = await tx.stockEntry.delete({
                 where: {
-                    id: idSelected
+                    id: stockEntry.id
                 },
                 include: {
                     items: true

--- a/backend/src/controller/stockEntries.controller.js
+++ b/backend/src/controller/stockEntries.controller.js
@@ -1,4 +1,5 @@
 import prisma from "../db.js"
+import { filterByDate } from "../utils/filterByDate.js"
 
 export const createStockEntry = async(req, res) => {
     try {
@@ -50,6 +51,7 @@ export const createStockEntry = async(req, res) => {
 
 export const getAllStockEntries = async(req, res) => {
     try {
+        const where = filterByDate(req.query)
         const allStockEntries = await prisma.stockEntry.findMany({
         include: {
             items: {
@@ -62,7 +64,8 @@ export const getAllStockEntries = async(req, res) => {
                 }
             },
             user: true
-        }
+        },
+        where
         })
         return res.json(allStockEntries)
     } catch (error) {

--- a/backend/src/middlewares/salesMiddlewares.js
+++ b/backend/src/middlewares/salesMiddlewares.js
@@ -66,7 +66,12 @@ export const validateNewSale = async(req, res, next) => {
 export const validateSaleExist = async (req, res, next) => {
     try {
         const id = req.params.id
-        const saleExist = await prisma.sales.findFirst({where: id})
+        const saleExist = await prisma.sales.findFirst({
+            where: {id: id},
+            include: {
+                items: true
+            }
+        })
         if (!saleExist) return res.json({error: "El id no corresponde a ninguna venta"})
         req.sale = saleExist
         next()

--- a/backend/src/middlewares/salesMiddlewares.js
+++ b/backend/src/middlewares/salesMiddlewares.js
@@ -66,9 +66,9 @@ export const validateNewSale = async(req, res, next) => {
 export const validateSaleExist = async (req, res, next) => {
     try {
         const id = req.params.id
-        const idExist = await prisma.sales.findFirst({where: id})
-        if (!idExist) return res.json({error: "El id no corresponde a ninguna venta"})
-            
+        const saleExist = await prisma.sales.findFirst({where: id})
+        if (!saleExist) return res.json({error: "El id no corresponde a ninguna venta"})
+        req.sale = saleExist
         next()
     } catch (error) {
         res.status(500).json({ error: "Error interno durante el proceso" });

--- a/backend/src/middlewares/salesMiddlewares.js
+++ b/backend/src/middlewares/salesMiddlewares.js
@@ -63,3 +63,14 @@ export const validateNewSale = async(req, res, next) => {
     }
 }
 
+export const validateSaleExist = async (req, res, next) => {
+    try {
+        const id = req.params.id
+        const idExist = await prisma.sales.findFirst({where: id})
+        if (!idExist) return res.json({error: "El id no corresponde a ninguna venta"})
+            
+        next()
+    } catch (error) {
+        res.status(500).json({ error: "Error interno durante el proceso" });
+    }
+}

--- a/backend/src/middlewares/stockEntriesMiddlewares.js
+++ b/backend/src/middlewares/stockEntriesMiddlewares.js
@@ -48,3 +48,18 @@ export const validateStockEntry = async(req, res, next) => {
         return res.status(500).json({ error: "Error interno durante el proceso" });
     }
 }
+
+export const validateStockEntryExist = async(req, res, next) => {
+    try {
+        const id = req.params.id
+        const stockEntryExist = await prisma.stockEntry.findFirst({
+            where: {id: id},
+            include: {items: true}
+        })
+        if (!stockEntryExist) return res.json({error: "El Id no corresponde a ninguna entrada"})
+        req.stockEntry = stockEntryExist
+        next()
+    } catch (error) {
+        return res.status(500).json({ error: "Error interno durante el proceso" });
+    }
+}

--- a/backend/src/routes/sales.routes.js
+++ b/backend/src/routes/sales.routes.js
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { createNewSale, deleteSale, getAllSales } from "../controller/sales.controller.js";
+import { createNewSale, deleteSale, getAllSales, updateSale } from "../controller/sales.controller.js";
 import { validateNewSale, validateSaleExist } from "../middlewares/salesMiddlewares.js";
 import { authenticate } from "../middlewares/authMiddlewares.js";
 
@@ -10,4 +10,6 @@ router.post('/sales', authenticate, validateNewSale, createNewSale)
 router.get('/sales', getAllSales)
 
 router.delete('/sales/:id',validateSaleExist, deleteSale)
+
+router.put('/sales/:id', validateSaleExist, updateSale)
 export default router

--- a/backend/src/routes/sales.routes.js
+++ b/backend/src/routes/sales.routes.js
@@ -11,5 +11,4 @@ router.get('/sales', getAllSales)
 
 router.delete('/sales/:id',validateSaleExist, deleteSale)
 
-router.put('/sales/:id', validateSaleExist, updateSale)
 export default router

--- a/backend/src/routes/sales.routes.js
+++ b/backend/src/routes/sales.routes.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { createNewSale, deleteSale, getAllSales } from "../controller/sales.controller.js";
-import { validateNewSale } from "../middlewares/salesMiddlewares.js";
+import { validateNewSale, validateSaleExist } from "../middlewares/salesMiddlewares.js";
 import { authenticate } from "../middlewares/authMiddlewares.js";
 
 const router = Router()
@@ -9,5 +9,5 @@ router.post('/sales', authenticate, validateNewSale, createNewSale)
 
 router.get('/sales', getAllSales)
 
-router.delete('/sales/:id', deleteSale)
+router.delete('/sales/:id',validateSaleExist, deleteSale)
 export default router

--- a/backend/src/routes/sales.routes.js
+++ b/backend/src/routes/sales.routes.js
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { createNewSale, deleteSale, getAllSales, updateSale } from "../controller/sales.controller.js";
+import { createNewSale, deleteSale, getAllSales } from "../controller/sales.controller.js";
 import { validateNewSale, validateSaleExist } from "../middlewares/salesMiddlewares.js";
 import { authenticate } from "../middlewares/authMiddlewares.js";
 

--- a/backend/src/routes/stockEntries.route.js
+++ b/backend/src/routes/stockEntries.route.js
@@ -1,11 +1,11 @@
 import { Router} from "express"
 import { createStockEntry, getAllStockEntries, deleteEntry } from "../controller/stockEntries.controller.js"
-import { validateStockEntry } from "../middlewares/stockEntriesMiddlewares.js"
+import { validateStockEntry, validateStockEntryExist } from "../middlewares/stockEntriesMiddlewares.js"
 import { authenticate } from "../middlewares/authMiddlewares.js"
 const router = Router()
 
 router.post('/entries', authenticate, validateStockEntry, createStockEntry)
 router.get('/entries', getAllStockEntries)
-router.delete('/entries/:id', deleteEntry)
+router.delete('/entries/:id', validateStockEntryExist,  deleteEntry)
 
 export default router

--- a/backend/src/utils/filterByDate.js
+++ b/backend/src/utils/filterByDate.js
@@ -1,0 +1,32 @@
+export const filterByDate = ({year, month, minDay, maxDay}) => {
+    const currentDate = new Date()
+    const yearNum = Number(year) || currentDate.getFullYear()
+    const monthNum = Number(month) || currentDate.getMonth()
+    const minDayNum = Number(minDay) || 1
+    const lastDayMonth = new Date (yearNum, monthNum , 0)
+    const maxDayNum = Number(maxDay) || lastDayMonth.getDate()
+    const where = {}
+
+    where.date = {}
+    if (year){
+        if (month){
+            where.date.gte= new Date (yearNum, monthNum -1, minDayNum)
+            if (minDay){
+                if (maxDay){
+                    where.date.lt = new Date (yearNum, monthNum -1, maxDayNum +1)
+                }else {
+                    where.date.lt = new Date (yearNum, monthNum - 1, minDayNum + 1)
+                }
+            }else {
+                where.date.lt = new Date (yearNum, monthNum -1, maxDayNum +1)
+            }
+        }else {
+            where.date.gte = new Date (yearNum, 0, 1)
+            where.date.lt = new Date (yearNum + 1, 0, 0)
+        }
+    }else {
+        where.date.gte = new Date (yearNum, monthNum, minDayNum)
+        where.date.lt = new Date (yearNum, monthNum, maxDayNum)
+    }
+    return where
+}

--- a/frontend/src/hooks/useSales.js
+++ b/frontend/src/hooks/useSales.js
@@ -27,6 +27,7 @@ export function useSales () {
             body:JSON.stringify(saleData),
         })
         const data = await res.json()
+        setSales((prev) => ({...prev, data}))
         toast("Venta registrada con exito!")
         fetchProducts()
         return data
@@ -40,6 +41,7 @@ export function useSales () {
             }
         })
         const data = await res.json()
+        setSales((prev) => (prev.filter((s => s.id !== saleId))))
         toast("Venta eliminada con exito!")
     }
 

--- a/frontend/src/hooks/useSales.js
+++ b/frontend/src/hooks/useSales.js
@@ -6,8 +6,8 @@ export function useSales () {
     const [sales, setSales] = useState()
     const { fetchProducts} = useProducts()
 
-    const getAllSales = async() => {
-        const res = await fetch('http://localhost:3000/api/sales',{
+    const getAllSales = async(query) => {
+        const res = await fetch(`http://localhost:3000/api/sales?${query}`,{
             method: 'GET',
             headers: {
                 "content-type": "application/json"

--- a/frontend/src/hooks/useSales.js
+++ b/frontend/src/hooks/useSales.js
@@ -3,7 +3,8 @@ import { toast } from "../utils/notifyToast.js";
 import { useState } from "react"
 
 export function useSales () {
-    const [sales, setSales] = useState()
+    const [sales, setSales] = useState([])
+    const [totalPages, setTotalPages] = useState()
     const { fetchProducts} = useProducts()
 
     const getAllSales = async(query) => {
@@ -14,7 +15,8 @@ export function useSales () {
             }
         })
         const data = await res.json()
-        setSales(data)
+        setSales(data.allSales)
+        setTotalPages(data.pagination.totalPages)
     }
 
     const createSale = async(saleData) => {
@@ -47,6 +49,7 @@ export function useSales () {
 
     return {
         sales,
+        totalPages,
         getAllSales,
         createSale,
         deleteSale

--- a/frontend/src/hooks/useStockEntries.js
+++ b/frontend/src/hooks/useStockEntries.js
@@ -6,8 +6,8 @@ export function useStockEntries () {
     const [stockEntries, setStockEntries] = useState([])
     const {updateVariantToProduct} = useProducts()
 
-    const getAllStockEntries = async() => {
-        const res = await fetch('http://localhost:3000/api/entries', {
+    const getAllStockEntries = async(query) => {
+        const res = await fetch(`http://localhost:3000/api/entries?${query}`, {
             method: 'GET',
             headers: {
                 "content-type": "application/json"

--- a/frontend/src/hooks/useStockEntries.js
+++ b/frontend/src/hooks/useStockEntries.js
@@ -4,6 +4,7 @@ import { useState } from "react"
 
 export function useStockEntries () {
     const [stockEntries, setStockEntries] = useState([])
+    const [totalPages, setTotalPages] = useState()
     const {updateVariantToProduct} = useProducts()
 
     const getAllStockEntries = async(query) => {
@@ -14,7 +15,8 @@ export function useStockEntries () {
             }
         })
         const data = await res.json()
-        setStockEntries(data)
+        setStockEntries(data.allStockEntries)
+        setTotalPages(data.pagination.totalPages)
     }
 
     const createEntry = async(entryData) => {
@@ -55,6 +57,7 @@ export function useStockEntries () {
 
     return {
         stockEntries,
+        totalPages,
         getAllStockEntries,
         createEntry,
         deleteEntry

--- a/frontend/src/hooks/useStockEntries.js
+++ b/frontend/src/hooks/useStockEntries.js
@@ -1,3 +1,4 @@
+import { toast } from "../utils/notifyToast.js"
 import { useProducts } from "../context/ProductContext"
 import { useState } from "react"
 
@@ -40,9 +41,22 @@ export function useStockEntries () {
         }
     }
 
+    const deleteEntry = async(id) => {
+        const res = await fetch(`http://localhost:3000/api/entries/${id}`,{
+            method: 'DELETE',
+            headers: {
+                "Content-Type": "application/json"
+            }
+        })
+        const data = await res.json()
+        setStockEntries((prev) => (prev.filter(e => e.id !== id)))
+        toast("Entrada eliminada con exito!")
+    }
+
     return {
         stockEntries,
         getAllStockEntries,
-        createEntry
+        createEntry,
+        deleteEntry
     }
 }

--- a/frontend/src/pages/SalesPage.jsx
+++ b/frontend/src/pages/SalesPage.jsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useState } from "react";
 import { useSales } from "../hooks/useSales.js";
-import { Button, Table, Box, DataList, Image, Grid, GridItem } from "@chakra-ui/react";
+import { Button, Table, Box, DataList, Image, Grid, GridItem, Stack, Text, Strong } from "@chakra-ui/react";
 import Calendar from "react-calendar";
 import Modal from "../components/Modal.jsx";
 
@@ -9,8 +9,8 @@ export function SaleSelectedModal({ saleSelected }) {
         <Box>
             <DataList.Root orientation="horizontal" divideY="1px" maxW="md">
                 <DataList.Item pt="4">
-                    <DataList.ItemLabel>Vendedor ID</DataList.ItemLabel>
-                    <DataList.ItemValue>{saleSelected.userId}</DataList.ItemValue>
+                    <DataList.ItemLabel>Vendedor</DataList.ItemLabel>
+                    <DataList.ItemValue>{saleSelected.user.name} {saleSelected.user.lastName}</DataList.ItemValue>
                 </DataList.Item>
                 <DataList.Item pt="4">
                     <DataList.ItemLabel>Fecha</DataList.ItemLabel>
@@ -21,10 +21,18 @@ export function SaleSelectedModal({ saleSelected }) {
                     <DataList.ItemValue>{saleSelected.motive}</DataList.ItemValue>
                 </DataList.Item>
                 <DataList.Item pt="4">
-                    <DataList.ItemLabel>Productos</DataList.ItemLabel>
+                    <DataList.ItemLabel>Producto/s</DataList.ItemLabel>
                     <Grid templateColumns="repeat(3, 1fr)" gap="4">
                         {saleSelected.items.map(item => (
-                            <Image key={item.variant.id} src={item.variant.image} h="full" w="40px" fit="contain" />
+                            <Box key={item.id} display="flex" flexDirection="column" textAlign="center" width="100px">
+                                <Image src={item.variant.image} h="100px" w="400px" fit="contain" />
+                                <Stack display="flex" flexDirection="column" textAlign="initial" justifyContent="flex-end" width="100%" height="100%">
+                                    <Strong fontWeight="semibold" textStyle="sm">{item.variant.product.name} {item.variant.product.brand}</Strong>
+                                    <Text color="fg.muted" textStyle="sm">Codigo: {item.variant.code}</Text>
+                                    <Text color="fg.muted" textStyle="sm">Cantidad: {item.quantity}</Text>
+                                    <Text color="fg.muted" textStyle="sm">Precio Unitario: $ {new Intl.NumberFormat("es-AR").format(item.unitPrice)}</Text>
+                                </Stack>
+                            </Box>
                         ))}
                     </Grid>
                 </DataList.Item>
@@ -74,12 +82,13 @@ function SalesPage() {
                 </Box>
             </GridItem>
             <GridItem rowSpan={9} colSpan={7} display="flex" flexDirection="column" marginLeft="260px" marginTop="60px" width="92%">
-                <Table.Root size="sm" striped>
+                <Table.Root marginLeft="10px" size="sm" striped width="99%">
                     <Table.Caption>Product inventory and pricing information</Table.Caption>
                     <Table.Header>
                         <Table.Row>
                             <Table.ColumnHeader>Vendedor</Table.ColumnHeader>
                             <Table.ColumnHeader>Fecha</Table.ColumnHeader>
+                            <Table.ColumnHeader>+ Info</Table.ColumnHeader>
                             <Table.ColumnHeader>Productos</Table.ColumnHeader>
                             <Table.ColumnHeader>Precio Unitario</Table.ColumnHeader>
                             <Table.ColumnHeader>Precio Final</Table.ColumnHeader>
@@ -91,7 +100,8 @@ function SalesPage() {
                         {sales && sales.map((sale) => (
                             <Table.Row key={sale.id}>
                                 <Table.Cell>{sale.user.name} {sale.user.lastName}</Table.Cell>
-                                <Table.Cell>{sale.date}
+                                <Table.Cell>{sale.date.slice(0, 10)}</Table.Cell>
+                                <Table.Cell>
                                     <Modal trigger={<Button size="sm" variant="surface" onClick={() => { handleSaleSelected(sale) }}>+Info</Button>}>
                                         <SaleSelectedModal saleSelected={saleSelected} />
                                     </Modal>

--- a/frontend/src/pages/SalesPage.jsx
+++ b/frontend/src/pages/SalesPage.jsx
@@ -37,7 +37,7 @@ export function SaleSelectedModal({ saleSelected }) {
 }
 
 function SalesPage() {
-    const { getAllSales, sales } = useSales()
+    const { getAllSales, sales, deleteSale } = useSales()
     const [saleSelected, setSaleSelected] = useState([])
 
     useEffect(() => {
@@ -60,6 +60,7 @@ function SalesPage() {
                         <Table.ColumnHeader>Precio Unitario</Table.ColumnHeader>
                         <Table.ColumnHeader>Precio Final</Table.ColumnHeader>
                         <Table.ColumnHeader>Motivo</Table.ColumnHeader>
+                        <Table.ColumnHeader>Eliminar</Table.ColumnHeader>
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>
@@ -91,6 +92,12 @@ function SalesPage() {
                             </Table.Cell>
                             <Table.Cell>$ {new Intl.NumberFormat("es-AR").format(sale.totalPrice)}</Table.Cell>
                             <Table.Cell>{sale.motive}</Table.Cell>
+                            <Table.Cell>
+                                <Modal size={"sm"} trigger={<Button backgroundColor={"red.700"}>Delete</Button>}>
+                                    <h2 >Está seguro que desea eliminar esta venta?</h2>
+                                    <Button onClick={() => { deleteSale(sale.id) }}>Eliminar</Button>
+                                </Modal>
+                            </Table.Cell>
                         </Table.Row>
                     ))}
                 </Table.Body>

--- a/frontend/src/pages/SalesPage.jsx
+++ b/frontend/src/pages/SalesPage.jsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useState } from "react";
 import { useSales } from "../hooks/useSales.js";
-import { Button, Table, Box, DataList, Image, Grid, GridItem, Stack, Text, Strong } from "@chakra-ui/react";
+import { Button, Table, Box, DataList, Image, Grid, GridItem, Stack, Text, Strong, ButtonGroup, IconButton, Pagination } from "@chakra-ui/react";
 import Calendar from "react-calendar";
 import Modal from "../components/Modal.jsx";
 
@@ -46,14 +46,15 @@ export function SaleSelectedModal({ saleSelected }) {
 }
 
 function SalesPage() {
-    const { getAllSales, sales, deleteSale } = useSales()
+    const { getAllSales, sales, deleteSale, totalPages } = useSales()
     const [saleSelected, setSaleSelected] = useState([])
     const [filters, setFilters] = useState()
+    const [page, setPage] = useState(1)
 
     useEffect(() => {
         const query = new URLSearchParams(filters).toString()
         getAllSales(query)
-    }, [filters])
+    }, [filters, page])
 
     const handleSaleSelected = (sale) => {
         setSaleSelected(sale)
@@ -70,6 +71,11 @@ function SalesPage() {
                 : setFilters({ year: year })
     }
 
+    const handleChangePage = (page) => {
+        setPage(page)
+        setFilters((prev) => ({ ...prev, page: page }))
+    }
+
     return (
         <Grid templateColumns="repeat(8, 1fr)" templateRows="repeat(10, 1fr)">
             <GridItem rowSpan={10} colSpan={1} padding="4" bg="black" display="flex" flexDirection="column" justifyContent="center" gap="4" position="fixed" top="50px" zIndex="50" bottom="0">
@@ -83,7 +89,6 @@ function SalesPage() {
             </GridItem>
             <GridItem rowSpan={9} colSpan={7} display="flex" flexDirection="column" marginLeft="260px" marginTop="60px" width="92%">
                 <Table.Root marginLeft="10px" size="sm" striped width="99%">
-                    <Table.Caption>Product inventory and pricing information</Table.Caption>
                     <Table.Header>
                         <Table.Row>
                             <Table.ColumnHeader>Vendedor</Table.ColumnHeader>
@@ -136,6 +141,21 @@ function SalesPage() {
                         ))}
                     </Table.Body>
                 </Table.Root>
+                <Box display="flex" justifyContent="center">
+                    <Pagination.Root count={(totalPages * 2)} pageSize={2} page={page} onPageChange={(e) => handleChangePage(e.page)}>
+                        <ButtonGroup gap="4" size="sm" variant="ghost">
+                            <Pagination.PrevTrigger asChild>
+                                <IconButton>
+                                </IconButton>
+                            </Pagination.PrevTrigger>
+                            <Pagination.PageText />
+                            <Pagination.NextTrigger asChild>
+                                <IconButton>
+                                </IconButton>
+                            </Pagination.NextTrigger>
+                        </ButtonGroup>
+                    </Pagination.Root>
+                </Box>
             </GridItem>
         </Grid>
     )

--- a/frontend/src/pages/SalesPage.jsx
+++ b/frontend/src/pages/SalesPage.jsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useState } from "react";
 import { useSales } from "../hooks/useSales.js";
-import { Button, Table, Box, DataList, Image, Grid } from "@chakra-ui/react";
+import { Button, Table, Box, DataList, Image, Grid, GridItem } from "@chakra-ui/react";
+import Calendar from "react-calendar";
 import Modal from "../components/Modal.jsx";
 
 export function SaleSelectedModal({ saleSelected }) {
@@ -39,70 +40,94 @@ export function SaleSelectedModal({ saleSelected }) {
 function SalesPage() {
     const { getAllSales, sales, deleteSale } = useSales()
     const [saleSelected, setSaleSelected] = useState([])
+    const [filters, setFilters] = useState()
 
     useEffect(() => {
-        getAllSales()
-    }, [])
+        const query = new URLSearchParams(filters).toString()
+        getAllSales(query)
+    }, [filters])
 
     const handleSaleSelected = (sale) => {
         setSaleSelected(sale)
     }
 
+    const handleChangeDate = (value, selected) => {
+        const year = value.getFullYear()
+        const month = value.getMonth() + 1
+        const minDay = value.getDate()
+        selected === "month"
+            ? setFilters({ year: year, month: month })
+            : selected === "day"
+                ? setFilters({ year: year, month: month, minDay: minDay })
+                : setFilters({ year: year })
+    }
+
     return (
-        <Box paddingTop="60px">
-            <Table.Root size="sm" striped>
-                <Table.Caption>Product inventory and pricing information</Table.Caption>
-                <Table.Header>
-                    <Table.Row>
-                        <Table.ColumnHeader>Vendedor</Table.ColumnHeader>
-                        <Table.ColumnHeader>Fecha</Table.ColumnHeader>
-                        <Table.ColumnHeader>Productos</Table.ColumnHeader>
-                        <Table.ColumnHeader>Precio Unitario</Table.ColumnHeader>
-                        <Table.ColumnHeader>Precio Final</Table.ColumnHeader>
-                        <Table.ColumnHeader>Motivo</Table.ColumnHeader>
-                        <Table.ColumnHeader>Eliminar</Table.ColumnHeader>
-                    </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                    {sales && sales.map((sale) => (
-                        <Table.Row key={sale.id}>
-                            <Table.Cell>{sale.user.name} {sale.user.lastName}</Table.Cell>
-                            <Table.Cell>{sale.date}
-                                <Modal trigger={<Button size="sm" variant="surface" onClick={() => { handleSaleSelected(sale) }}>+Info</Button>}>
-                                    <SaleSelectedModal saleSelected={saleSelected} />
-                                </Modal>
-                            </Table.Cell>
-                            <Table.Cell>
-                                {sale.items.map(item => (
-                                    <Fragment key={item.id}>
-                                        <Box display="flex" flexDirection="column" key={item.variant.id}>
-                                            {item.quantity} {item.variant.product.name} {item.variant.product.brand}
-                                        </Box>
-                                    </Fragment>
-                                ))}
-                            </Table.Cell>
-                            <Table.Cell>
-                                {sale.items.map(item => (
-                                    <Fragment key={item.id}>
-                                        <Box display="flex" flexDirection="column" key={item.variant.id}>
-                                            $ {new Intl.NumberFormat("es-AR").format(item.unitPrice)}
-                                        </Box>
-                                    </Fragment>
-                                ))}
-                            </Table.Cell>
-                            <Table.Cell>$ {new Intl.NumberFormat("es-AR").format(sale.totalPrice)}</Table.Cell>
-                            <Table.Cell>{sale.motive}</Table.Cell>
-                            <Table.Cell>
-                                <Modal size={"sm"} trigger={<Button backgroundColor={"red.700"}>Delete</Button>}>
-                                    <h2 >Está seguro que desea eliminar esta venta?</h2>
-                                    <Button onClick={() => { deleteSale(sale.id) }}>Eliminar</Button>
-                                </Modal>
-                            </Table.Cell>
+        <Grid templateColumns="repeat(8, 1fr)" templateRows="repeat(10, 1fr)">
+            <GridItem rowSpan={10} colSpan={1} padding="4" bg="black" display="flex" flexDirection="column" justifyContent="center" gap="4" position="fixed" top="50px" zIndex="50" bottom="0">
+                <Box width="240px">
+                    <Calendar
+                        onClickMonth={(value, e) => { handleChangeDate(value, "month") }}
+                        onClickYear={(value, e) => { handleChangeDate(value, "year") }}
+                        onClickDay={(value, e) => { handleChangeDate(value, "day") }}
+                    />
+                </Box>
+            </GridItem>
+            <GridItem rowSpan={9} colSpan={7} display="flex" flexDirection="column" marginLeft="260px" marginTop="60px" width="92%">
+                <Table.Root size="sm" striped>
+                    <Table.Caption>Product inventory and pricing information</Table.Caption>
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.ColumnHeader>Vendedor</Table.ColumnHeader>
+                            <Table.ColumnHeader>Fecha</Table.ColumnHeader>
+                            <Table.ColumnHeader>Productos</Table.ColumnHeader>
+                            <Table.ColumnHeader>Precio Unitario</Table.ColumnHeader>
+                            <Table.ColumnHeader>Precio Final</Table.ColumnHeader>
+                            <Table.ColumnHeader>Motivo</Table.ColumnHeader>
+                            <Table.ColumnHeader>Eliminar</Table.ColumnHeader>
                         </Table.Row>
-                    ))}
-                </Table.Body>
-            </Table.Root>
-        </Box>
+                    </Table.Header>
+                    <Table.Body>
+                        {sales && sales.map((sale) => (
+                            <Table.Row key={sale.id}>
+                                <Table.Cell>{sale.user.name} {sale.user.lastName}</Table.Cell>
+                                <Table.Cell>{sale.date}
+                                    <Modal trigger={<Button size="sm" variant="surface" onClick={() => { handleSaleSelected(sale) }}>+Info</Button>}>
+                                        <SaleSelectedModal saleSelected={saleSelected} />
+                                    </Modal>
+                                </Table.Cell>
+                                <Table.Cell>
+                                    {sale.items.map(item => (
+                                        <Fragment key={item.id}>
+                                            <Box display="flex" flexDirection="column" key={item.variant.id}>
+                                                {item.quantity} {item.variant.product.name} {item.variant.product.brand}
+                                            </Box>
+                                        </Fragment>
+                                    ))}
+                                </Table.Cell>
+                                <Table.Cell>
+                                    {sale.items.map(item => (
+                                        <Fragment key={item.id}>
+                                            <Box display="flex" flexDirection="column" key={item.variant.id}>
+                                                $ {new Intl.NumberFormat("es-AR").format(item.unitPrice)}
+                                            </Box>
+                                        </Fragment>
+                                    ))}
+                                </Table.Cell>
+                                <Table.Cell>$ {new Intl.NumberFormat("es-AR").format(sale.totalPrice)}</Table.Cell>
+                                <Table.Cell>{sale.motive}</Table.Cell>
+                                <Table.Cell>
+                                    <Modal size={"sm"} trigger={<Button backgroundColor={"red.700"}>Delete</Button>}>
+                                        <h2 >Está seguro que desea eliminar esta venta?</h2>
+                                        <Button onClick={() => { deleteSale(sale.id) }}>Eliminar</Button>
+                                    </Modal>
+                                </Table.Cell>
+                            </Table.Row>
+                        ))}
+                    </Table.Body>
+                </Table.Root>
+            </GridItem>
+        </Grid>
     )
 }
 

--- a/frontend/src/pages/StockEntries.jsx
+++ b/frontend/src/pages/StockEntries.jsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { Fragment } from "react"
 import { useStockEntries } from "../hooks/useStockEntries.js";
-import { Button, Table, Box, DataList, Image, Grid, Stack } from "@chakra-ui/react";
+import { Button, Table, Box, DataList, Image, Grid, GridItem, Stack } from "@chakra-ui/react";
 import Modal from "../components/Modal.jsx";
+import Calendar from "react-calendar"
 
 export function EntrySelectedModal({ entrySelected }) {
     return (
@@ -49,64 +50,89 @@ export function EntrySelectedModal({ entrySelected }) {
 function StockEntriesPage() {
     const { getAllStockEntries, stockEntries, deleteEntry } = useStockEntries()
     const [entrySelected, setEntrySelected] = useState([])
+    const [filters, setFilters] = useState()
     useEffect(() => {
-        getAllStockEntries()
-    }, [])
+        const query = new URLSearchParams(filters).toString()
+        getAllStockEntries(query)
+    }, [filters])
 
 
     const handleEntrySelected = (entry) => {
         setEntrySelected(entry)
     }
 
+    const handleChangeDate = (value, selected) => {
+        const year = value.getFullYear()
+        const month = value.getMonth() + 1
+        const minDay = value.getDate()
+        selected === "month"
+            ? setFilters({ year: year, month: month })
+            : selected === "day"
+                ? setFilters({ year: year, month: month, minDay: minDay })
+                : setFilters({ year: year })
+    }
+
     return (
-        <Box paddingTop="60px">
-            <Table.Root size="sm" striped>
-                <Table.Caption>Product inventory and pricing information</Table.Caption>
-                <Table.Header>
-                    <Table.Row>
-                        <Table.ColumnHeader>Vendedor</Table.ColumnHeader>
-                        <Table.ColumnHeader>Fecha</Table.ColumnHeader>
-                        <Table.ColumnHeader>Producto</Table.ColumnHeader>
-                        <Table.ColumnHeader>Cantidad</Table.ColumnHeader>
-                        <Table.ColumnHeader>Precio unidad</Table.ColumnHeader>
-                        <Table.ColumnHeader>Compra total</Table.ColumnHeader>
-                        <Table.ColumnHeader>Motivo</Table.ColumnHeader>
-                        <Table.ColumnHeader>Eliminar</Table.ColumnHeader>
-                    </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                    {stockEntries && stockEntries.map((entry) => (
-                        <Table.Row key={entry.id}>
-                            <Table.Cell>{entry.user.name} {entry.user.lastName}</Table.Cell>
-                            <Table.Cell>{entry.date}
-                                <Modal trigger={<Button size="sm" variant="surface" onClick={() => { handleEntrySelected(entry) }}>+Info</Button>}>
-                                    <EntrySelectedModal entrySelected={entrySelected} />
-                                </Modal>
-                            </Table.Cell>
-                            {entry.items.map((item) => (
-                                <Fragment key={item.id}>
-                                    <Table.Cell key={item.id}>
-                                        <Box display="flex" alignItems="center">
-                                            {item.variant.product.name} {item.variant.product.brand}
-                                        </Box>
-                                    </Table.Cell>
-                                    <Table.Cell textStyle="lg" color="green">+ {item.quantity}</Table.Cell>
-                                    <Table.Cell>$ {new Intl.NumberFormat("es-AR").format(item.purchasePrice)}</Table.Cell>
-                                </Fragment>
-                            ))}
-                            <Table.Cell>$ {new Intl.NumberFormat("es-AR").format(entry.total)}</Table.Cell>
-                            <Table.Cell>{entry.motive}</Table.Cell>
-                            <Table.Cell>
-                                <Modal size={"sm"} trigger={<Button backgroundColor={"red.700"}>Delete</Button>}>
-                                    <h2 >Está seguro que desea eliminar esta entrada?</h2>
-                                    <Button onClick={() => { deleteEntry(entry.id) }}>Eliminar</Button>
-                                </Modal>
-                            </Table.Cell>
+        <Grid templateColumns="repeat(8, 1fr)" templateRows="repeat(10, 1fr)">
+            <GridItem rowSpan={10} colSpan={1} padding="4" bg="black" display="flex" flexDirection="column" justifyContent="center" gap="4" position="fixed" top="50px" zIndex="50" bottom="0">
+                <Box width="240px">
+                    <Calendar
+                        onClickMonth={(value, e) => { handleChangeDate(value, "month") }}
+                        onClickYear={(value, e) => { handleChangeDate(value, "year") }}
+                        onClickDay={(value, e) => { handleChangeDate(value, "day") }}
+                    />
+                </Box>
+            </GridItem>
+
+            <GridItem rowSpan={9} colSpan={7} display="flex" flexDirection="column" marginLeft="260px" marginTop="60px" width="92%">
+                <Table.Root size="sm" striped>
+                    <Table.Caption>Product inventory and pricing information</Table.Caption>
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.ColumnHeader>Vendedor</Table.ColumnHeader>
+                            <Table.ColumnHeader>Fecha</Table.ColumnHeader>
+                            <Table.ColumnHeader>Producto</Table.ColumnHeader>
+                            <Table.ColumnHeader>Cantidad</Table.ColumnHeader>
+                            <Table.ColumnHeader>Precio unidad</Table.ColumnHeader>
+                            <Table.ColumnHeader>Compra total</Table.ColumnHeader>
+                            <Table.ColumnHeader>Motivo</Table.ColumnHeader>
+                            <Table.ColumnHeader>Eliminar</Table.ColumnHeader>
                         </Table.Row>
-                    ))}
-                </Table.Body>
-            </Table.Root>
-        </Box>
+                    </Table.Header>
+                    <Table.Body>
+                        {stockEntries && stockEntries.map((entry) => (
+                            <Table.Row key={entry.id}>
+                                <Table.Cell>{entry.user.name} {entry.user.lastName}</Table.Cell>
+                                <Table.Cell>{entry.date}
+                                    <Modal trigger={<Button size="sm" variant="surface" onClick={() => { handleEntrySelected(entry) }}>+Info</Button>}>
+                                        <EntrySelectedModal entrySelected={entrySelected} />
+                                    </Modal>
+                                </Table.Cell>
+                                {entry.items.map((item) => (
+                                    <Fragment key={item.id}>
+                                        <Table.Cell key={item.id}>
+                                            <Box display="flex" alignItems="center">
+                                                {item.variant.product.name} {item.variant.product.brand}
+                                            </Box>
+                                        </Table.Cell>
+                                        <Table.Cell textStyle="lg" color="green">+ {item.quantity}</Table.Cell>
+                                        <Table.Cell>$ {new Intl.NumberFormat("es-AR").format(item.purchasePrice)}</Table.Cell>
+                                    </Fragment>
+                                ))}
+                                <Table.Cell>$ {new Intl.NumberFormat("es-AR").format(entry.total)}</Table.Cell>
+                                <Table.Cell>{entry.motive}</Table.Cell>
+                                <Table.Cell>
+                                    <Modal size={"sm"} trigger={<Button backgroundColor={"red.700"}>Delete</Button>}>
+                                        <h2 >Está seguro que desea eliminar esta entrada?</h2>
+                                        <Button onClick={() => { deleteEntry(entry.id) }}>Eliminar</Button>
+                                    </Modal>
+                                </Table.Cell>
+                            </Table.Row>
+                        ))}
+                    </Table.Body>
+                </Table.Root>
+            </GridItem>
+        </Grid >
     )
 }
 

--- a/frontend/src/pages/StockEntries.jsx
+++ b/frontend/src/pages/StockEntries.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Fragment } from "react"
 import { useStockEntries } from "../hooks/useStockEntries.js";
-import { Button, Table, Box, DataList, Image, Grid, GridItem, Stack } from "@chakra-ui/react";
+import { Button, Table, Box, DataList, Image, Grid, GridItem, Stack, Text, Strong } from "@chakra-ui/react";
 import Modal from "../components/Modal.jsx";
 import Calendar from "react-calendar"
 
@@ -15,7 +15,7 @@ export function EntrySelectedModal({ entrySelected }) {
                 </DataList.Item>
                 <DataList.Item pt="4">
                     <DataList.ItemLabel>Vendedor ID</DataList.ItemLabel>
-                    <DataList.ItemValue>{entrySelected.userId}</DataList.ItemValue>
+                    <DataList.ItemValue>{entrySelected.user.name} {entrySelected.user.lastName}</DataList.ItemValue>
                 </DataList.Item>
                 <DataList.Item pt="4">
                     <DataList.ItemLabel>Motivo</DataList.ItemLabel>
@@ -25,22 +25,21 @@ export function EntrySelectedModal({ entrySelected }) {
                     <DataList.ItemLabel>Producto</DataList.ItemLabel>
                     <Grid templateColumns="repeat(3, 1fr)" gap="4">
                         {entrySelected.items.map(item => (
-                            <Box key={item.id}>
-                                <Image src={item.variant.image} />
-                                <Stack>
-                                    {item.variant.product.name} {item.variant.product.brand}
+                            <Box key={item.id} display="flex" flexDirection="column" textAlign="center" width="100px">
+                                <Image src={item.variant.image} h="100px" w="400px" fit="contain" />
+                                <Stack display="flex" flexDirection="column" textAlign="initial" justifyContent="flex-end" width="100%" height="100%">
+                                    <Strong fontWeight="semibold" textStyle="sm">{item.variant.product.name} {item.variant.product.brand}</Strong>
+                                    <Text color="fg.muted" textStyle="sm">Codigo: {item.variant.code}</Text>
+                                    <Text color="fg.muted" textStyle="sm">Cantidad: {item.quantity}</Text>
+                                    <Text color="fg.muted" textStyle="sm">Precio Unitario: $ {new Intl.NumberFormat("es-AR").format(item.purchasePrice)}</Text>
                                 </Stack>
-                                {item.variant.code}
                             </Box>
                         ))}
                     </Grid>
                 </DataList.Item>
                 <DataList.Item pt="4">
-                    <DataList.ItemLabel>Cantidad</DataList.ItemLabel>
-                    {entrySelected.items.map(item => (
-                        <DataList.ItemValue key={item.id}>{item.quantity} ${item.purchasePrice}</DataList.ItemValue>
-                    ))
-                    }
+                    <DataList.ItemLabel>Precio Final</DataList.ItemLabel>
+                    <DataList.ItemValue>$ {new Intl.NumberFormat("es-AR").format(entrySelected.total)}</DataList.ItemValue>
                 </DataList.Item>
             </DataList.Root>
         </Box>
@@ -85,12 +84,13 @@ function StockEntriesPage() {
             </GridItem>
 
             <GridItem rowSpan={9} colSpan={7} display="flex" flexDirection="column" marginLeft="260px" marginTop="60px" width="92%">
-                <Table.Root size="sm" striped>
+                <Table.Root marginLeft="10px" size="sm" striped width="99%">
                     <Table.Caption>Product inventory and pricing information</Table.Caption>
                     <Table.Header>
                         <Table.Row>
                             <Table.ColumnHeader>Vendedor</Table.ColumnHeader>
                             <Table.ColumnHeader>Fecha</Table.ColumnHeader>
+                            <Table.ColumnHeader>+ Info</Table.ColumnHeader>
                             <Table.ColumnHeader>Producto</Table.ColumnHeader>
                             <Table.ColumnHeader>Cantidad</Table.ColumnHeader>
                             <Table.ColumnHeader>Precio unidad</Table.ColumnHeader>
@@ -103,7 +103,8 @@ function StockEntriesPage() {
                         {stockEntries && stockEntries.map((entry) => (
                             <Table.Row key={entry.id}>
                                 <Table.Cell>{entry.user.name} {entry.user.lastName}</Table.Cell>
-                                <Table.Cell>{entry.date}
+                                <Table.Cell>{entry.date.slice(0, 10)}</Table.Cell>
+                                <Table.Cell>
                                     <Modal trigger={<Button size="sm" variant="surface" onClick={() => { handleEntrySelected(entry) }}>+Info</Button>}>
                                         <EntrySelectedModal entrySelected={entrySelected} />
                                     </Modal>

--- a/frontend/src/pages/StockEntries.jsx
+++ b/frontend/src/pages/StockEntries.jsx
@@ -47,7 +47,7 @@ export function EntrySelectedModal({ entrySelected }) {
 }
 
 function StockEntriesPage() {
-    const { getAllStockEntries, stockEntries } = useStockEntries()
+    const { getAllStockEntries, stockEntries, deleteEntry } = useStockEntries()
     const [entrySelected, setEntrySelected] = useState([])
     useEffect(() => {
         getAllStockEntries()
@@ -71,6 +71,7 @@ function StockEntriesPage() {
                         <Table.ColumnHeader>Precio unidad</Table.ColumnHeader>
                         <Table.ColumnHeader>Compra total</Table.ColumnHeader>
                         <Table.ColumnHeader>Motivo</Table.ColumnHeader>
+                        <Table.ColumnHeader>Eliminar</Table.ColumnHeader>
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>
@@ -95,6 +96,12 @@ function StockEntriesPage() {
                             ))}
                             <Table.Cell>$ {new Intl.NumberFormat("es-AR").format(entry.total)}</Table.Cell>
                             <Table.Cell>{entry.motive}</Table.Cell>
+                            <Table.Cell>
+                                <Modal size={"sm"} trigger={<Button backgroundColor={"red.700"}>Delete</Button>}>
+                                    <h2 >Está seguro que desea eliminar esta entrada?</h2>
+                                    <Button onClick={() => { deleteEntry(entry.id) }}>Eliminar</Button>
+                                </Modal>
+                            </Table.Cell>
                         </Table.Row>
                     ))}
                 </Table.Body>

--- a/frontend/src/pages/StockEntries.jsx
+++ b/frontend/src/pages/StockEntries.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Fragment } from "react"
 import { useStockEntries } from "../hooks/useStockEntries.js";
-import { Button, Table, Box, DataList, Image, Grid, GridItem, Stack, Text, Strong } from "@chakra-ui/react";
+import { Button, Table, Box, DataList, Image, Grid, GridItem, Stack, Text, Strong, Pagination, ButtonGroup, IconButton } from "@chakra-ui/react";
 import Modal from "../components/Modal.jsx";
 import Calendar from "react-calendar"
 
@@ -47,13 +47,15 @@ export function EntrySelectedModal({ entrySelected }) {
 }
 
 function StockEntriesPage() {
-    const { getAllStockEntries, stockEntries, deleteEntry } = useStockEntries()
+    const { getAllStockEntries, stockEntries, deleteEntry, totalPages } = useStockEntries()
     const [entrySelected, setEntrySelected] = useState([])
     const [filters, setFilters] = useState()
+    const [page, setPage] = useState(1)
+
     useEffect(() => {
         const query = new URLSearchParams(filters).toString()
         getAllStockEntries(query)
-    }, [filters])
+    }, [filters, page])
 
 
     const handleEntrySelected = (entry) => {
@@ -71,6 +73,11 @@ function StockEntriesPage() {
                 : setFilters({ year: year })
     }
 
+    const handleChangePage = (page) => {
+        setPage(page)
+        setFilters((prev) => ({ ...prev, page: page }))
+    }
+
     return (
         <Grid templateColumns="repeat(8, 1fr)" templateRows="repeat(10, 1fr)">
             <GridItem rowSpan={10} colSpan={1} padding="4" bg="black" display="flex" flexDirection="column" justifyContent="center" gap="4" position="fixed" top="50px" zIndex="50" bottom="0">
@@ -85,7 +92,6 @@ function StockEntriesPage() {
 
             <GridItem rowSpan={9} colSpan={7} display="flex" flexDirection="column" marginLeft="260px" marginTop="60px" width="92%">
                 <Table.Root marginLeft="10px" size="sm" striped width="99%">
-                    <Table.Caption>Product inventory and pricing information</Table.Caption>
                     <Table.Header>
                         <Table.Row>
                             <Table.ColumnHeader>Vendedor</Table.ColumnHeader>
@@ -132,6 +138,21 @@ function StockEntriesPage() {
                         ))}
                     </Table.Body>
                 </Table.Root>
+                <Box display="flex" justifyContent="center">
+                    <Pagination.Root count={(totalPages * 2)} pageSize={2} page={page} onPageChange={(e) => handleChangePage(e.page)}>
+                        <ButtonGroup gap="4" size="sm" variant="ghost">
+                            <Pagination.PrevTrigger asChild>
+                                <IconButton>
+                                </IconButton>
+                            </Pagination.PrevTrigger>
+                            <Pagination.PageText />
+                            <Pagination.NextTrigger asChild>
+                                <IconButton>
+                                </IconButton>
+                            </Pagination.NextTrigger>
+                        </ButtonGroup>
+                    </Pagination.Root>
+                </Box>
             </GridItem>
         </Grid >
     )


### PR DESCRIPTION
### 🚀 Enhancement: eliminación y paginación en ventas y entradas de stock

- Se agregaron endpoints para eliminar ventas y entradas de stock (`DELETE /api/sales/:id`, `DELETE /api/stock-entries/:id`).
- Se implementó la paginación en `getAllSales` y `getAllStockEntries` usando `skip`, `take`, `count` y `orderBy`.
- Las respuestas de ambos endpoints ahora incluyen metadata de paginación.
- Se mantuvo la compatibilidad con los filtros de fecha existentes.
- `useSales` y `useStockEntries` ahora consumen la metadata de paginación y la exponen en el hook.
- `SalesPage` y `StockEntriesPage` incluyen un componente de paginación para navegar entre páginas.
- Se agregaron modales de confirmación para eliminar ventas y entradas.
- Ahora se pueden eliminar ventas y entradas de stock desde la interfaz.
- Los registros se muestran con paginación, mejorando la performance y usabilidad.
- Flujo completo probado con filtros dinámicos de fecha y paginación.

Closes #41 